### PR TITLE
unescape html characters in templates, hide error codes so tests work, run CI in 3.11

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
         # TODO: remove `7.1` in the next release
         pytest-version: ["~=6.2", "~=7.1", "~=7.2"]
 

--- a/pytest_mypy_plugins/collect.py
+++ b/pytest_mypy_plugins/collect.py
@@ -77,7 +77,7 @@ class SafeLineLoader(yaml.SafeLoader):
         mapping = super().construct_mapping(node, deep=deep)
         # Add 1 so line numbering starts at 1
         starting_line = node.start_mark.line + 1
-        for (title_node, contents_node) in node.value:
+        for title_node, contents_node in node.value:
             if title_node.value == "main":
                 starting_line = title_node.start_mark.line + 1
         mapping["__line__"] = starting_line

--- a/pytest_mypy_plugins/item.py
+++ b/pytest_mypy_plugins/item.py
@@ -107,7 +107,7 @@ def run_mypy_typechecking(cmd_options: List[str]) -> int:
         build.build(sources, options, flush_errors=flush_errors, fscache=fscache)
 
     except SystemExit as sysexit:
-        return sysexit.code
+        return sysexit.code if isinstance(sysexit.code, int) else 1
     finally:
         fscache.flush()
 
@@ -241,7 +241,6 @@ class YamlTestItem(pytest.Item):
             temp_dir = tempfile.TemporaryDirectory(prefix="pytest-mypy-", dir=self.root_directory)
 
         except (FileNotFoundError, PermissionError, NotADirectoryError) as e:
-
             raise TypecheckAssertionError(
                 error_message=f"Testing base directory {self.root_directory} must exist and be writable"
             ) from e

--- a/pytest_mypy_plugins/tests/test-parametrized.yml
+++ b/pytest_mypy_plugins/tests/test-parametrized.yml
@@ -45,3 +45,5 @@
   out: |
     main:2: note: Revealed type is "{{ rt }}"
     main:4: error: Unsupported operand types for / ("str" and "int")
+  mypy_config: |
+    hide_error_codes = True

--- a/pytest_mypy_plugins/tests/test-paths-from-env.yml
+++ b/pytest_mypy_plugins/tests/test-paths-from-env.yml
@@ -11,3 +11,5 @@
       content: |
         def extra_fn() -> None:
             pass
+  mypy_config: |
+    hide_error_codes = True

--- a/pytest_mypy_plugins/tests/test-simple-cases.yml
+++ b/pytest_mypy_plugins/tests/test-simple-cases.yml
@@ -58,6 +58,8 @@
   main: |
     a = 1
     a.lower()  # E: "int" has no attribute "lower"
+  mypy_config: |
+    hide_error_codes = True
 
 
 - case: custom_mypy_config_strict_optional_true_set
@@ -88,6 +90,8 @@
   main: |
     a = 1
     a.lower()  # E: "int" has no attribute "lower"
+  mypy_config: |
+    hide_error_codes = True
 
 - case: fail_if_message_does_not_match
   expect_fail: yes

--- a/pytest_mypy_plugins/tests/test_parametrized_html_escape.yml
+++ b/pytest_mypy_plugins/tests/test_parametrized_html_escape.yml
@@ -1,0 +1,11 @@
+- case: gt_in_rt
+  parametrized:
+    - val: bool
+      rt: def (builtins.object =) -> builtins.bool
+  main: |
+    reveal_type({{ val }})  # N: Revealed type is "{{ rt }}"
+
+
+- case: gt_in_comment
+  main: |
+    reveal_type(bool)  # N: Revealed type is "def (builtins.object =) -> builtins.bool"

--- a/pytest_mypy_plugins/utils.py
+++ b/pytest_mypy_plugins/utils.py
@@ -351,8 +351,26 @@ def extract_output_matchers_from_out(out: str, params: Mapping[str, Any], regex:
     return matchers
 
 
+def _html_unescape(string: str) -> str:
+    """remove HTML escaping on all of these " & < >"""
+
+    html_codes = {
+        "&quot;": '"',
+        "&lt;": "<",
+        "&gt;": ">",
+    }
+
+    for char in html_codes:
+        string = string.replace(char, html_codes[char])
+    # & must be handled last
+    string = string.replace("&amp;", "&")
+    return string
+
+
 def render_template(template: str, data: Mapping[str, Any]) -> str:
-    return chevron.render(template=template, data={k: v if v is not None else "None" for k, v in data.items()})
+    return _html_unescape(
+        chevron.render(template=template, data={k: v if v is not None else "None" for k, v in data.items()})
+    )
 
 
 def get_func_first_lnum(attr: Callable[..., None]) -> Optional[Tuple[int, List[str]]]:

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Typing :: Typed",
     ],
 )


### PR DESCRIPTION
fix html characters in parametrized values that automatically get escaped by chevron. Also some minor fixed due to updates to mypy & black